### PR TITLE
update

### DIFF
--- a/commands/Hypixel.php
+++ b/commands/Hypixel.php
@@ -244,6 +244,22 @@ class Hypixel {
 						SpelakoUtils::div($p['stats']['SkyWars']['wins'], $p['stats']['SkyWars']['losses'])
 					]
 				);
+			/*
+			// 不想写了 想睡觉
+			case 'buildbattle':	
+			case 'bb':
+				return SpelakoUtils::buildString(
+					$this->getMessage('bb.layout'),
+					[
+						$rank.$p['displayname'],
+						number_format($p['stats']['UHC']['score']),
+						number_format($p['stats']['UHC']['coins']),
+						number_format($p['stats']['UHC']['wins']),
+						number_format($p['stats']['UHC']['kills']),
+						number_format($p['stats']['UHC']['deaths']),
+						SpelakoUtils::div($p['stats']['UHC']['kills'], $p['stats']['UHC']['deaths'])
+					]
+				);*/
 			case 'bedwars':
 			case 'bw':
 				if(empty($args[3])) {
@@ -395,7 +411,7 @@ class Hypixel {
 				]);
 			case 'zombies':
 			case 'zb':
-				$map = match(isset($args[3]) ? $args[3] : 'all') {
+				$map = match(isset($args[3]) ? $args[3] : 'fastView') {
 					'deadend', 'de' => [
 						'mapKeys' => ['_deadend', 'Dead End'], // 0: key for stats; 1: key for map display name
 						'bossKeys' => ['tnt', 'inferno', 'broodmother'],
@@ -411,9 +427,31 @@ class Hypixel {
 					'all' => [
 						'mapKeys' => ['', 'all']
 					],
+					'fastView' => [
+						'mapKeys' => ['', 'fastView']
+					],
 					default => null
 				};
 				if(is_null($map)) return $this->getMessage('zb.info.unknown_map');
+				if($map['mapKeys'][1] == 'fastView')
+					return SpelakoUtils::buildString(
+					$this->getMessage('zb.layout_fastView'),
+					[
+						$rank.$p['displayname'],
+						number_format($p['stats']['Arcade']['total_rounds_survived_zombies']),
+						number_format($p['stats']['Arcade']['wins_zombies']),
+						100 * SpelakoUtils::div($p['stats']['Arcade']['bullets_hit_zombies'], $p['stats']['Arcade']['bullets_shot_zombies']),
+						100 * SpelakoUtils::div($p['stats']['Arcade']['headshots_zombies'], $p['stats']['Arcade']['bullets_hit_zombies']),
+						$p['stats']['Arcade']['wins_zombies_deadend_normal'] > 0 ? number_format($p['stats']['Arcade']['wins_zombies_deadend_normal']) : ($p['stats']['Arcade']['total_rounds_survived_zombies_deadend_normal'] == 0? '-':'['.number_format($p['stats']['Arcade']['best_round_zombies_deadend_normal']).']'),
+						$p['stats']['Arcade']['wins_zombies_deadend_hard'] > 0 ? number_format($p['stats']['Arcade']['wins_zombies_deadend_hard']) : ($p['stats']['Arcade']['total_rounds_survived_zombies_deadend_hard'] == 0? '-':'['.number_format($p['stats']['Arcade']['best_round_zombies_deadend_hard']).']'),
+						$p['stats']['Arcade']['wins_zombies_deadend_rip'] > 0 ? number_format($p['stats']['Arcade']['wins_zombies_deadend_rip']) : ($p['stats']['Arcade']['total_rounds_survived_zombies_deadend_rip'] == 0? '-':'['.number_format($p['stats']['Arcade']['best_round_zombies_deadend_rip']).']'),
+						$p['stats']['Arcade']['wins_zombies_badblood_normal'] > 0 ? number_format($p['stats']['Arcade']['wins_zombies_badblood_normal']) : ($p['stats']['Arcade']['total_rounds_survived_zombies_badblood_normal'] == 0? '-':'['.number_format($p['stats']['Arcade']['best_round_zombies_badblood_normal']).']'),
+						$p['stats']['Arcade']['wins_zombies_badblood_hard'] > 0 ? number_format($p['stats']['Arcade']['wins_zombies_badblood_hard']) : ($p['stats']['Arcade']['total_rounds_survived_zombies_badblood_hard'] == 0? '-':'['.number_format($p['stats']['Arcade']['best_round_zombies_badblood_hard']).']'),
+						$p['stats']['Arcade']['wins_zombies_badblood_rip'] > 0 ? number_format($p['stats']['Arcade']['wins_zombies_badblood_rip']) : ($p['stats']['Arcade']['total_rounds_survived_zombies_badblood_rip'] == 0? '-':'['.number_format($p['stats']['Arcade']['best_round_zombies_badblood_rip']).']'),
+						$p['stats']['Arcade']['wins_zombies_alienarcadium_normal'] > 0 ? number_format($p['stats']['Arcade']['wins_zombies_alienarcadium_normal']) : ($p['stats']['Arcade']['total_rounds_survived_zombies_alienarcadium_normal'] == 0? '-':'['.number_format($p['stats']['Arcade']['best_round_zombies_alienarcadium_normal']).']'),
+						$footer
+					]
+				);
 
 				$difficulty = match($map['mapKeys'][0] == '_alienarcadium' ? 'normal' : (isset($args[4]) ? $args[4] : 'general')) {
 					'normal', 'norm' => ['_normal', 'normal'], // 0: key for stats; 1: key for map display name
@@ -825,7 +863,7 @@ class Hypixel {
 							SpelakoUtils::buildString(
 								$this->getMessage('general.placeholders.last_logout'),
 								[
-									SpelakoUtils::formatTime($p['lastLogout'], format:'Y-m-d H:i:s')
+									empty($p['lastLogin']) ? $this->getMessage('general.placeholders.no_access') : SpelakoUtils::formatTime($p['lastLogout'], format:'Y-m-d H:i:s')
 								]
 							)
 						),
@@ -837,7 +875,8 @@ class Hypixel {
 								$status ? ($this->getMessage('maps.'.($status['map'] ?? 'none')) ?? (' '.$status['map'].' ')) : ''
 							]
 						),
-						$footer
+						$footer,
+						number_format($p['rewardScore'])
 					]
 				);
 		}

--- a/resources/hypixel.json
+++ b/resources/hypixel.json
@@ -113,6 +113,18 @@
 				"胜场: %8$s | 败场: %9$s | W/L: %10$.3f"
 			]
 		},
+		"bb": {
+			"layout": [
+				"%1$s 的建筑大师统计信息:",
+				"聊天称号: %2$s (%3$s/%4$s) | 硬币: %5$s",
+				"游戏: %5$s | 胜场: $6$s",
+				"单人 1.8 - 单人 1.14 - 团队 - 高手 - 建筑猜猜乐",
+				"",
+				"",
+				""
+				
+			]
+		},
 		"bw": {
 			"layout": [
 				"%1$s 的起床战争%2$s统计信息:",
@@ -170,6 +182,15 @@
 			}
 		},
 		"zb": {
+			"layout_fastView": [
+				"%1$s 的僵尸末日全局 Fast View 信息:",
+				"生存总回合数: %2$s | 胜场: %3$s",
+				"命中率: %4$.1f%% | 爆头率 %5$.1f%%",
+				"胜场或[最佳回合]（普通/困难/安息）",
+				"穷途末路：%6$s/%7$s/%8$s",
+				"坏血之宫：%9$s/%10$s/%11$s",
+				"外星游乐园：%12$s"
+			],
 			"layout": [
 				"%1$s 的僵尸末日%2$s地图%3$s统计信息:",
 				"生存总回合数: %4$s | 胜场: %5$s | 最佳回合: %6$s",
@@ -220,6 +241,7 @@
 				"unknown_map": [
 					"未知的地图.",
 					"目前支持的地图可以是下列之一:",
+					"- all",
 					"- deadend, de",
 					"- badblood, bb",
 					"- alienarcadium, aa"
@@ -265,6 +287,7 @@
 				"成就点数: %4$s | 小游戏胜场: %5$s",
 				"完成任务: %6$s | 完成挑战: %7$s",
 				"获得硬币: %8$s | 使用语言: %9$s",
+				"每日看广告奖励当前连续领取: %16$s 天",
 				"最近游玩: %10$s",
 				"首次登录: %11$s",
 				"上次登录: %12$s",
@@ -311,8 +334,8 @@
 			"combat_3": "末地",
 			"mining_1": "黄金矿区",
 			"mining_2": "深层矿洞",
-			"mining_3": " Dwarven Mine ",
-			"mining_4": " Crystal Hollows ",
+			"mining_3": "矮人矿坑",
+			"mining_4": "水晶矿洞",
 			"foraging_1": "公园",
 			"dungeon_hub": "地牢大厅",
 			"dungeon": "地牢",
@@ -332,7 +355,7 @@
 			"teams_insane_slime": "双人史莱姆模式",
 			"solo_insane_lucky": "单挑幸运方块模式",
 			"teams_insane_lucky": "双人幸运方块模式",
-			"solo_insane_hunters_vs_beasts": "狩猎对决模式",
+			"solo_insane_hunters_vs_beasts": "兽猎对决模式",
 
 			"TNTRUN": "方块掘战",
 			"PVPRUN": "PVP 方块掘战",
@@ -392,10 +415,11 @@
 			"NORMAL_PARTY": "挑战模式 - 爆破模式",
 			"DEATHMATCH_PARTY": "挑战模式 - 团队死亡竞赛模式",
 
-			"BUILD_BATTLE_SOLO_NORMAL": "单人模式",
-			"BUILD_BATTLE_TEAMS_NORMAL": "团队模式",
-			"BUILD_BATTLE_SOLO_PRO": "高手模式",
-			"BUILD_BATTLE_GUESS_THE_BUILD": "建筑猜猜乐",
+			"SOLO_NORMAL": "单人模式 1.8",
+			"TEAMS_NORMAL": "团队模式",
+			"SOLO_PRO": "高手模式",
+			"SOLO_NORMAL_LATEST": "单人模式 1.14 ",
+			"GUESS_THE_BUILD": "建筑猜猜乐",
 
 			"SOLO": "单挑模式",
 			"TEAMS": "组队模式",
@@ -433,6 +457,8 @@
 			"TOWERWARS_TEAM_OF_TWO": "塔防战争双人模式",
 			
 			"PIXEL_PARTY": " Pixel Party ",
+			"INVADERS" : "Invaders",
+
 			"PIT": ""
 		},
 		"games": {
@@ -474,6 +500,8 @@
 			"Dead End": "穷途末路",
 			"Bad Blood": "坏血之宫",
 			"Alien Arcadium": "外星游乐园",
+			
+			"Guess The Build": "",
 
 			"Amazon": "亚马逊雨林",
 			"Waterfall": "瀑布",
@@ -605,6 +633,8 @@
 			"Atherrough Valley": "神魔之城",
 			"Arches": "失落山谷",
 			"Arathi": "远郊乡村"
+			
+			
 		},
 		"languages": {
 			"ENGLISH": "英语",
@@ -623,6 +653,20 @@
 			"CZECH": "捷克语",
 			"FINNISH": "芬兰语",
 			"GREEK": "希腊语"
+		},
+		"buildbattle_Rank":{
+			"Rookie": "初来乍到",
+			"Untrained": "未经雕琢",
+			"Amateur": "初窥门径",
+			"Apprentice": "学有所成",
+			"Experienced": "驾轻就熟",
+			"Seasoned": "历练老成",
+			"Trained": "技艺精湛",
+			"Skilled": "炉火纯青",
+			"Talented": "技惊四座",
+			"Professional": "巧夺天工",
+			"Expert": "闻名于世",
+			"Master": "名垂青史"
 		}
 	}
 }


### PR DESCRIPTION
Fixed：修复了部分游戏名
Changed: 僵尸末日查询不带地图名时默认进入 Fast View 视图，原全局查询移植到  all 地图中
Added: 正在增加建筑大师查询（todo
主查询中增加了看广告天数（大概会移除吧

btw 空岛等级为空时，记得帮它标上个一级